### PR TITLE
Adding test cases for misplaced certificates

### DIFF
--- a/diagnosticsModule/Private/AdfsProxyHealthChecks.ps1
+++ b/diagnosticsModule/Private/AdfsProxyHealthChecks.ps1
@@ -58,31 +58,6 @@ Function TestSTSReachableFromProxy()
     }
 }
 
-Function TestNoNonSelfSignedCertificatesInRootStore
-{
-    $testName = "TestNoNonSelfSignedCertificateInRootStore";
-    $testResult = New-Object TestResult -ArgumentList($testName)
-    $certificateOutputKey = "NonSelfSignedCertificates";
-
-    try
-    {
-        $nonSelfSignedCertificates = Get-ChildItem Cert:\LocalMachine\root -Recurse | Where-Object {$_.Issuer -ne $_.Subject} | Select-Object FriendlyName, Issuer, Subject, Thumbprint;
-
-        if ($nonSelfSignedCertificates.Count -ne 0)
-        {
-            $testResult.Detail = "There were non-self-signed certificates found in the root store. Move them to the intermediate store.";
-            $testResult.Result = [ResultType]::Fail;
-            $testResult.Output = @{$certificateOutputKey = $nonSelfSignedCertificates};
-        }
-
-        return $testResult;
-    }
-    catch [Exception]
-    {
-        return Create-ErrorExceptionTestResult $testName $_.Exception
-    }
-}
-
 Function TestProxySslBindings
 {
     Param(

--- a/diagnosticsModule/Private/TestUtilities.ps1
+++ b/diagnosticsModule/Private/TestUtilities.ps1
@@ -114,7 +114,9 @@ Function TestAdfsSTSHealth()
             "TestTrustedDevicesCertificateStore", `
             "TestAdfsPatches", `
             "TestServicePrincipalName", `
-            "TestTLSMismatch");
+            "TestTLSMismatch", `
+            "TestNonSelfSignedCertificatesInRootStore", `
+            "TestSelfSignedCertificatesInIntermediateCaStore");
 
     if (($adfsServers -eq $null) -or ($adfsServers.Count -eq 0))
     {
@@ -251,9 +253,10 @@ Function TestAdfsProxyHealth()
             "TestIsAdfsRunning", `
             "TestIsAdfsProxyRunning", `
             "TestSTSReachableFromProxy", `
-            "TestNoNonSelfSignedCertificatesInRootStore", `
             "TestTLSMismatch", `
-            "TestTimeSync");
+            "TestTimeSync", `
+            "TestNonSelfSignedCertificatesInRootStore", `
+            "TestSelfSignedCertificatesInIntermediateCaStore");
 
     if ([string]::IsNullOrWhiteSpace($sslThumbprint))
     {


### PR DESCRIPTION
- Added new test case for misplaced root certificates in the
intermediate CA store
- Moved test for non-self signed certificates in root store to common
health checks
- Addressing issue #16