### PR TITLE
Fix TestProxySsslBidings missing thumbprint bug

### DIFF
--- a/diagnosticsModule/Private/TestUtilities.ps1
+++ b/diagnosticsModule/Private/TestUtilities.ps1
@@ -280,7 +280,7 @@ Function TestAdfsProxyHealth()
         }
     }
     else
-    {   
+    {
         $functionsToRun += "TestProxySslBindings -AdfsSslThumbprint `$functionArguments.AdfsSslThumbprint";
     }
 

--- a/diagnosticsModule/Private/TestUtilities.ps1
+++ b/diagnosticsModule/Private/TestUtilities.ps1
@@ -270,11 +270,7 @@ Function TestAdfsProxyHealth()
             "TestNonSelfSignedCertificatesInRootStore", `
             "TestSelfSignedCertificatesInIntermediateCaStore");
 
-    if ([string]::IsNullOrWhiteSpace($sslThumbprint))
-    {
-        $functionsToRun += "TestProxySslBindings";
-    }
-    else
+    if (-not [string]::IsNullOrWhiteSpace($sslThumbprint))
     {
         $functionsToRun += "TestProxySslBindings -AdfsSslThumbprint `$functionArguments.AdfsSslThumbprint";
     }

--- a/diagnosticsModule/Private/TestUtilities.ps1
+++ b/diagnosticsModule/Private/TestUtilities.ps1
@@ -270,8 +270,17 @@ Function TestAdfsProxyHealth()
             "TestNonSelfSignedCertificatesInRootStore", `
             "TestSelfSignedCertificatesInIntermediateCaStore");
 
-    if (-not [string]::IsNullOrWhiteSpace($sslThumbprint))
+    if ([string]::IsNullOrWhiteSpace($sslThumbprint))
     {
+        # Attempt to load first the synthetic transactions library to test if Connect Health is the executer of the script
+        ipmo .\Microsoft.Identity.Health.Adfs.SyntheticTransactions.dll -ErrorAction SilentlyContinue -ErrorVariable synthTxErrVar
+        if ($synthTxErrVar -ne $null)
+        {
+            $functionsToRun += "TestProxySslBindings"
+        }
+    }
+    else 
+    {       
         $functionsToRun += "TestProxySslBindings -AdfsSslThumbprint `$functionArguments.AdfsSslThumbprint";
     }
 

--- a/diagnosticsModule/Private/TestUtilities.ps1
+++ b/diagnosticsModule/Private/TestUtilities.ps1
@@ -279,8 +279,8 @@ Function TestAdfsProxyHealth()
             $functionsToRun += "TestProxySslBindings"
         }
     }
-    else 
-    {       
+    else
+    {   
         $functionsToRun += "TestProxySslBindings -AdfsSslThumbprint `$functionArguments.AdfsSslThumbprint";
     }
 


### PR DESCRIPTION
We were hitting a failure in AAD Connect Health because the TestProxySsslBidings test requires a thumbprint for the SSL cert but we had an option to call the test even if we didn't have the cert.  
Modified the code to only call the TestProxySsslBidings test if we have the SSL thumbprint.