### PR TITLE
Add logic to lookup up service account user in the forest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,6 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# Visual Studio Code
+.vscode/

--- a/diagnosticsModule/Private/AdfsHealthChecks.ps1
+++ b/diagnosticsModule/Private/AdfsHealthChecks.ps1
@@ -377,7 +377,9 @@ Function TestADFSDuplicateSPN
             }
             else
             {
-                throw "Unable to find user object in AD for the service account $adfsServiceAccount."
+                $testResult.Result = [ResultType]::NotRun;
+                $testResult.Detail = "Unable to find user object in AD for the service account $adfsServiceAccount.";
+                return $testResult;
             }
         }
         else
@@ -1094,7 +1096,9 @@ Function TestServicePrincipalName
             }
             else
             {
-                throw "Unable to find user object in AD for the service account $adfsServiceAccount."
+                $testResult.Result = [ResultType]::NotRun;
+                $testResult.Detail = "Unable to find user object in AD for the service account $adfsServiceAccount.";
+                return $testResult;
             }
         }
         else 

--- a/diagnosticsModule/Private/AdfsHealthChecks.ps1
+++ b/diagnosticsModule/Private/AdfsHealthChecks.ps1
@@ -360,13 +360,13 @@ Function TestADFSDuplicateSPN
             throw "ADFS Service account is null or empty. The WMI configuration is in an inconsistent state"
         }
 
-        # Verify User is either in domain\user format or UPN format, get the domain and username values and make Service account is in the domain\user format.
+        # Verify User is either in domain\user format or UPN format and get the user and domain names
         if (IsUserPrincipalNameFormat($adfsServiceAccount))
         {
             $serviceAccountPartsUpn = $adfsServiceAccount.Split('@')
             if ($serviceAccountPartsUpn.Length -ne 2)
             {
-                throw "Unexpected value of the service account $adfsServiceAccount. Expected in DOMAIN\\User format or UPN:User@Domain"
+                throw "Unexpected value of the service account $adfsServiceAccount. Expected in UPN:User@Domain format"
             }
 
             $serviceSamAccountName = $serviceAccountPartsUpn[0]
@@ -387,7 +387,7 @@ Function TestADFSDuplicateSPN
             $serviceAccountParts = $adfsServiceAccount.Split('\\')
             if ($serviceAccountParts.Length -ne 2)
             {
-                throw "Unexpected value of the service account $adfsServiceAccount. Expected in DOMAIN\\User format or UPN:User@Domain"
+                throw "Unexpected value of the service account $adfsServiceAccount. Expected in DOMAIN\\User"
             }
             $serviceAccountDomain = $serviceAccountParts[0]
             $serviceSamAccountName = $serviceAccountParts[1]

--- a/diagnosticsModule/Test/Private/AdfsHealthChecks.Test.ps1
+++ b/diagnosticsModule/Test/Private/AdfsHealthChecks.Test.ps1
@@ -124,6 +124,7 @@ InModuleScope ADFSDiagnosticsModule {
                 Mock -CommandName Retrieve-AdfsProperties -MockWith { return New-Object PSObject -Property @{ "Hostname" = $_hostname }}
                 Mock -CommandName Invoke-Expression -MockWith { return @("Existing SPN found!", $_path) } -ParameterFilter { $Command -eq "setspn -f -q HOST/$_hostname"}
                 Mock -CommandName Invoke-Expression -MockWith { return @("Existing SPN found!", $_path) } -ParameterFilter { $Command -eq "setspn -f -q HTTP/$_hostname"}
+                Mock -CommandName TryGetDomainNameFromUpn -MockWith { return "contoso.com" }
             }
 
             It "should pass when service account is in UPN format" {
@@ -169,6 +170,7 @@ InModuleScope ADFSDiagnosticsModule {
                 Mock -CommandName GetObjectsFromAD -MockWith { return New-Object PSObject -Property @{ "Path" = $_fullPath } }
                 Mock -CommandName Retrieve-AdfsProperties -MockWith { return New-Object PSObject -Property @{ "Hostname" = $_hostname }}
                 Mock -CommandName Get-WmiObject -MockWith { return New-Object PSObject -Property @{ "StartName" = $_upnServiceAccount; "Name" = $adfsServiceName } }
+                Mock -CommandName TryGetDomainNameFromUpn -MockWith { return "contoso.com" }
             }
 
             It "when no HOST SPN is found" {


### PR DESCRIPTION
If user is in UPN format it is possible that the UPN does not contain the domain name that the user is actually in.  We are adding a "best effort" attempt at looking for the domain that the user is in.  First it looks for the user in the same domain that the STS is joined to.  Then it looks for the user in the forest that the computers domain is part of.  If it doesn't find it anywhere then we skip the test.