### PR TITLE
Fix IsUserPrincipalNameFormat and add logging

### DIFF
--- a/diagnosticsModule/Private/HelperUtilities.ps1
+++ b/diagnosticsModule/Private/HelperUtilities.ps1
@@ -558,7 +558,7 @@ Function IsUserPrincipalNameFormat
         return $false;
     }
 
-    return $toValidate -Match $EmailAddressRegex;
+    return $toValidate.Contains('@');
 }
 
 Function CheckRegistryKeyExist($key)

--- a/diagnosticsModule/Test/Private/AdfsHealthChecks.Test.ps1
+++ b/diagnosticsModule/Test/Private/AdfsHealthChecks.Test.ps1
@@ -209,6 +209,18 @@ InModuleScope ADFSDiagnosticsModule {
                 $ret.Result | should beexactly Fail
                 $ret.Detail | should beexactly "An existing SPN was found for HTTP/$_hostname but it did not resolve to the ADFS service account."
             }
+
+            It "when service account is not in expected SAM format" {
+                # Arrange
+                Mock -CommandName Get-WmiObject -MockWith { return New-Object PSObject -Property @{"Name" = $adfsServiceName; "StartName" = "badAccount"}}
+
+                # Act
+                $ret = TestServicePrincipalName
+
+                # Assert
+                $ret.Result | should beexactly Fail
+                $ret.Detail | should beexactly "Unexpected value for the service account badAccount. Expected in DOMAIN\\User"                
+            }
         }
 
         Context "should not run" {
@@ -270,19 +282,6 @@ InModuleScope ADFSDiagnosticsModule {
                 $ret.Result | should beexactly Error
                 $ret.ExceptionMessage | should beexactly "ADFS Service account is null or empty. The WMI configuration is in an inconsistent state"
                 $ret.Exception | should beexactly "System.Management.Automation.RuntimeException: ADFS Service account is null or empty. The WMI configuration is in an inconsistent state"
-            }
-
-            It "when service account is not in expected SAM format" {
-                # Arrange
-                Mock -CommandName Get-WmiObject -MockWith { return New-Object PSObject -Property @{"Name" = $adfsServiceName; "StartName" = "badAccount"}}
-
-                # Act
-                $ret = TestServicePrincipalName
-
-                # Assert
-                $ret.Result | should beexactly Error
-                $ret.ExceptionMessage | should beexactly "Unexpected value of the service account badAccount. Expected in DOMAIN\\User format or UPN:User@Domain"
-                $ret.Exception | should beexactly "System.Management.Automation.RuntimeException: Unexpected value of the service account badAccount. Expected in DOMAIN\\User format or UPN:User@Domain"
             }
         }
     }

--- a/diagnosticsModule/Test/Private/HelperUtilities.Test.ps1
+++ b/diagnosticsModule/Test/Private/HelperUtilities.Test.ps1
@@ -364,6 +364,72 @@ InModuleScope ADFSDiagnosticsModule {
             # Assert
             $ret | should beexactly $false
         }
+
+        It "should return true even if username has '$' in it" {
+            # Arrange
+            $username = 'test$name@test.contoso.com'
+
+            # Act
+            $ret = IsUserPrincipalNameFormat($username)
+
+            # Assert
+            $ret | should beexactly $true
+        }
+
+        It "should return true even if username has '-' in it" {
+            # Arrange
+            $username = 'test-name@test.contoso.com'
+
+            # Act
+            $ret = IsUserPrincipalNameFormat($username)
+            
+            # Assert
+            $ret | should beexactly $true
+        }
+
+        It "should return true even if username has '_' in it" {
+            # Arrange
+            $username = 'test_name@test.contoso.com'
+
+            # Act
+            $ret = IsUserPrincipalNameFormat($username)
+            
+            # Assert
+            $ret | should beexactly $true
+        }
+        
+        It "should return true even if username starts with an '_'" {
+            # Arrange
+            $username = '_testname@test.contoso.com'
+
+            # Act
+            $ret = IsUserPrincipalNameFormat($username)
+            
+            # Assert
+            $ret | should beexactly $true
+        }
+        
+        It "should return true even if username starts with an '-'" {
+            # Arrange
+            $username = '-testname@test.contoso.com'
+
+            # Act
+            $ret = IsUserPrincipalNameFormat($username)
+            
+            # Assert
+            $ret | should beexactly $true
+        }
+
+        It "should return true even if username starts with a '$'" {
+            # Arrange
+            $username = '$testname@test.contoso.com'
+
+            # Act
+            $ret = IsUserPrincipalNameFormat($username)
+
+            # Assert
+            $ret | should beexactly $true
+        }
     }
 
     Describe "GetDomainNameFromDistinguishedName" {


### PR DESCRIPTION
I modified IsUserPrincipalNameFormat to just check for the presence of the @ symbol in the username.  The regex was too complex and was failing when the username started with a symbol.

Added logic to handle LocalSystem account.

Added logging to help diagnose failures to connect to a domain.