### PR TITLE
Fix SPN not found errors

### DIFF
--- a/diagnosticsModule/Private/HelperUtilities.ps1
+++ b/diagnosticsModule/Private/HelperUtilities.ps1
@@ -355,9 +355,9 @@ Function GetObjectsFromAD ($domain, $filter, [switch] $GlobalCatalog)
         }
 
         $searcher.SearchScope = "SubTree"
-        $searcher.PropertiestoLoad.Add("distinguishedName")
-        $searcher.PropertiestoLoad.Add("objectGuid")
-        $searcher.PropertiestoLoad.Add("servicePrincipalName")
+        $Prop = $searcher.PropertiestoLoad.Add("distinguishedName")
+        $Prop = $searcher.PropertiestoLoad.Add("objectGuid")
+        $Prop = $searcher.PropertiestoLoad.Add("servicePrincipalName")
         $searcher.Filter = $filter
         $searchResults = $searcher.FindAll()
 

--- a/diagnosticsModule/Private/HelperUtilities.ps1
+++ b/diagnosticsModule/Private/HelperUtilities.ps1
@@ -355,9 +355,9 @@ Function GetObjectsFromAD ($domain, $filter, [switch] $GlobalCatalog)
         }
 
         $searcher.SearchScope = "SubTree"
-        $Prop = $searcher.PropertiestoLoad.Add("distinguishedName")
-        $Prop = $searcher.PropertiestoLoad.Add("objectGuid")
-        $Prop = $searcher.PropertiestoLoad.Add("servicePrincipalName")
+        $props = $searcher.PropertiestoLoad.Add("distinguishedName")
+        $props = $searcher.PropertiestoLoad.Add("objectGuid")
+        $props = $searcher.PropertiestoLoad.Add("servicePrincipalName")
         $searcher.Filter = $filter
         $searchResults = $searcher.FindAll()
 

--- a/diagnosticsModule/Private/HelperUtilities.ps1
+++ b/diagnosticsModule/Private/HelperUtilities.ps1
@@ -355,8 +355,9 @@ Function GetObjectsFromAD ($domain, $filter, [switch] $GlobalCatalog)
         }
 
         $searcher.SearchScope = "SubTree"
-        $props = $searcher.PropertiestoLoad.Add("distinguishedName")
-        $props = $searcher.PropertiestoLoad.Add("objectGuid")
+        $searcher.PropertiestoLoad.Add("distinguishedName")
+        $searcher.PropertiestoLoad.Add("objectGuid")
+        $searcher.PropertiestoLoad.Add("servicePrincipalName")
         $searcher.Filter = $filter
         $searchResults = $searcher.FindAll()
 


### PR DESCRIPTION
Some clients for Connect Health are failing to find the AD Object via the SPN.  Added checks to search the local directory before searching the global catalog.  And I check to see if the user object was found and if it has the correct spn configured.